### PR TITLE
QBCore import removal/Notify

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,3 +1,4 @@
+local QBCore = exports['qb-core']:GetCoreObject()
 local InLapdance = false
 local InCooldown = false
 local NearText = false

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -7,7 +7,6 @@ version '1.0'
 
 shared_scripts {
 	'config.lua',
-	'@qb-core/import.lua',
 	'locales/*.lua',
 }
 

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -3,8 +3,8 @@ Locale                          = Locale or {}
 Locale.en = { -- en is the reference that will be used for 'Config.Language'
 	StandaloneLapText			= "~r~E~w~ - Ask for a lap dance", -- Set the text that will be displayed above marker if 'Config.Framework' is set to 'standalone'
 	LapText						= "~r~E~w~ - Buy a lap dance (~g~" .. Config.LapDanceCost .. "$~w~)", -- Set the text that will be displayed above marker
-	BoughtLapdance				= "You just bought a lap dance for 100$", -- Notification text when a lap dance is bought
+	BoughtLapdance				= "You just bought a lap dance for $".. Config.LapDanceCost, -- Notification text when a lap dance is bought
 	StripperActive				= "The stripper is already busy!", -- Notification text if a stripper is already active when you try to buy a lap dance
 	StripperPause				= "The stripper needs some rest!", -- Notification text if a player wants to directly buy another lapdance within 10 seconds of finishing their last one
-	NotEnoughMoney				= "You do not have enough money. A lap dance costs 100$" -- Notification text if player don't have enough cash
+	NotEnoughMoney				= "You do not have enough money. A lap dance costs $".. Config.LapDanceCost -- Notification text if player don't have enough cash
 }

--- a/locales/fr.lua
+++ b/locales/fr.lua
@@ -3,8 +3,8 @@ Locale                          = Locale or {}
 Locale.fr = { -- fr is the reference that will be used for 'Config.Language'
 	StandaloneLapText			= "~r~E~w~ - Demander un lap dance", -- Définit le texte qui sera affiché au-dessus du marqueur si 'Config.Framework' est mis sur 'standalone'
 	LapText						= "~r~E~w~ - Acheter un lap dance (~g~" .. Config.LapDanceCost .. "$~w~)", -- Définit le texte qui sera affiché au-dessus du marqueur
-	BoughtLapdance				= "Vous avez acheté un lap dance pour 100$", -- Texte de la notification lorsqu'un lap dance est acheté
+	BoughtLapdance				= "Vous avez acheté un lap dance pour $".. Config.LapDanceCost, -- Texte de la notification lorsqu'un lap dance est acheté
 	StripperPause				= "La stripteaseuse a besoin de repos !", -- Texte de la notification si un joueur veut directement racheter un lapdance dans les 10 secondes après avoir fini son dernier
 	StripperActive				= "La strip-teaseuse est déjà occupé !", -- Texte de la notification si une strip-teaseuse est déjà occupé lorsque vous essayez d'acheter un lap dance
-	NotEnoughMoney				= "Vous n'avez pas assez d'argent. Un lap dance coûte 100$" -- Texte de la notification si le joueur n'a pas assez d'argent
+	NotEnoughMoney				= "Vous n'avez pas assez d'argent. Un lap dance coûte $".. Config.LapDanceCost -- Texte de la notification si le joueur n'a pas assez d'argent
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,4 +1,5 @@
 ESX = nil
+local QBCore = exports['qb-core']:GetCoreObject()
 
 local CurrentVersion = '1.1' -- Do Not Change This Value
 local NewestVersion = nil 


### PR DESCRIPTION
This pulls qbcore/import.lua from fxmanifest and adds the exports for getcoreobject to client/server.
Fixes the config.lapdancecost so when edits are made the notifications also reflect that.